### PR TITLE
Fix hang in pre-setup script

### DIFF
--- a/build/presetup.sh
+++ b/build/presetup.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 echo "Install packages"
-yum install python3 -y
-su - ec2-users
-pip3 install boto3 
-pip3 install flask 
+yum install python3 -ypip3 install boto3
+pip3 install flask
 mkdir -p /home/ec2-user/web_flask/templates

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -5,5 +5,4 @@ cp /tmp/web_flask.service /etc/systemd/system/web_flask.service
 cp /tmp/application.py /home/ec2-user/web_flask/application.py
 cp /tmp/index.html /home/ec2-user/web_flask/templates/index.html
 systemctl start web_flask
-systemctl status web_flask
-systemctl enable web_flask
+systemctl status web_flasksystemctl enable web_flask


### PR DESCRIPTION
## Summary
- clean up packer pre-setup script so it runs non-interactively
- trim trailing artifacts in setup script

## Testing
- `bash -n build/presetup.sh`
- `bash -n build/setup.sh`
- `python3 -m py_compile app/application.py`


------
https://chatgpt.com/codex/tasks/task_e_686e71bcf81c83239b275d7339ef7695