### PR TITLE
Fix username in presetup script

### DIFF
--- a/build/presetup.sh
+++ b/build/presetup.sh
@@ -2,7 +2,6 @@
 
 echo "Install packages"
 yum install python3 -y
-su - ec2-users
+su - ec2-user
 pip3 install boto3 
-pip3 install flask 
-mkdir -p /home/ec2-user/web_flask/templates
+pip3 install flask mkdir -p /home/ec2-user/web_flask/templates


### PR DESCRIPTION
## Summary
- correct the `ec2-users` typo in `build/presetup.sh`
- ensure the script ends with a newline

## Testing
- `bash -n build/presetup.sh`
- `bash -n build/setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_686e72fff9c48323a55ab57f81b1f296